### PR TITLE
Scrapbox_Enterprise_EULA_ja.md にアクセスしてきた人が困らないようにリネーム先を示す

### DIFF
--- a/Scrapbox_Enterprise_EULA_ja.md
+++ b/Scrapbox_Enterprise_EULA_ja.md
@@ -1,0 +1,2 @@
+## [Moved](./Scrapbox_on-premise_EULA_ja.md)
+


### PR DESCRIPTION
#2 でファイル名を変更したが、 まだ古いドキュメントから参照されている可能性はある為
https://github.com/nota/legal/blob/master/Scrapbox_Enterprise_EULA_ja.md にアクセスしてくる人はいるかもしれない。

リンクをはりました。

[![Image from Gyazo](https://i.gyazo.com/ca1c3eb638e16bfa9fe5fde6b3ddf1b2.gif)](https://gyazo.com/ca1c3eb638e16bfa9fe5fde6b3ddf1b2)

